### PR TITLE
Add ILK Frog task (called via socket)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ nltk
 scikit-learn>=0.13
 setuptools>=1.3.2
 weighwords
+unidecode

--- a/xtas/tasks/frog.py
+++ b/xtas/tasks/frog.py
@@ -1,0 +1,102 @@
+"""
+Wrapper around the ILK Frog lemmatizer/POS tagger
+
+The module expects frog to be running in server mode at localhost:9887
+
+Currently, the module is only tested with all frog modules active except for
+the NER and parser.
+
+The following line starts frog in the correct way:
+
+frog --skip=pm -S 9887
+
+See: http://ilk.uvt.nl/frog/
+"""
+
+from unidecode import unidecode
+import socket
+from StringIO import StringIO
+from itertools import takewhile
+import datetime
+
+FROG_HOST = "localhost"
+FROG_PORT = 9887
+
+_POSMAP = {"VZ": "P",
+           "N": "N",
+           "ADJ": "A",
+           "LET": ".",
+           "VNW": "O",
+           "LID": "D",
+           "SPEC": "M",
+           "TW": "Q",
+           "WW": "V",
+           "BW": "B",
+           "VG": "C",
+           "TSW": "I",
+           "MWU": "U",
+           "": "?",
+           }
+
+
+def call_frog(text):
+    """
+    Call the frog parser on the given host and port with the given text
+    Returns a file object containing the output lines.
+    """
+    if not text.endswith("\n"):
+        text = text + "\n"
+    if not isinstance(text, unicode):
+        text = unicode(text)
+    text = unidecode(text).encode("utf-8")
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((FROG_HOST, FROG_PORT))
+    s.sendall(text)
+    s.shutdown(socket.SHUT_WR)
+    for line in s.makefile('r'):
+        line = line.strip('\n')
+        if line == "READY":
+            return
+        else:
+            yield line
+
+
+def parse_frog(lines):
+    """
+    Interpret the output of the frog parser.
+    Input should be a sequence of lines (i.e. the output of call_frog)
+    Result is a sequence of dicts representing the tokens
+    """
+    sid = 0
+    for i, l in enumerate(lines):
+        if not l:
+            # end of sentence marker
+            sid += 1
+        else:
+            tid, token, lemma, morph, pos, conf = l.split("\t")[:6]
+            yield dict(id=i, sentence=sid, word=token, lemma=lemma,
+                       pos=pos, pos_confidence=float(conf))
+
+
+def add_pos1(token):
+    """
+    Adds a 'pos1' element to a frog token.
+    """
+    result = token.copy()
+    result['pos1'] = _POSMAP[token['pos'].split("(")[0]]
+    return result
+
+
+def frog_to_saf(tokens):
+    """
+    Convert frog tokens into a new SAF document
+    """
+    tokens = [add_pos1(token) for token in tokens]
+    module = {'module': "frog",
+              "started": datetime.datetime.now().isoformat()}
+    return {"header": {'format': "SAF",
+                       'format-version': "0.0",
+                       'processed': [module]
+                       },
+            "tokens": tokens}

--- a/xtas/tasks/single.py
+++ b/xtas/tasks/single.py
@@ -215,3 +215,27 @@ def untokenize(tokens):
     doc : string
     """
     return ' '.join(tokens)
+
+
+@app.task
+def frog(doc, output='raw'):
+    """
+    Run a document through the frog server at localhost:9887
+    If output is 'raw', returns the raw output lines.
+    If output is 'tokens', returns dictionaries for the tokens
+    If output is 'saf', returns a SAF dictionary
+    """
+    from .frog import call_frog, parse_frog, frog_to_saf
+    if output not in ('raw', 'tokens', 'saf'):
+        raise ValueError("Uknown output: {output}, "
+                         "please choose either raw, tokens, or saf"
+                         .format(**locals()))
+    text = fetch(doc)
+    result = call_frog(text)
+    if output == 'raw':
+        return list(result)
+    if output in ('tokens', 'saf'):
+        result = parse_frog(result)
+        if output == 'tokens':
+            return list(result)
+        return frog_to_saf(result)

--- a/xtas/tests/test_frog.py
+++ b/xtas/tests/test_frog.py
@@ -1,0 +1,81 @@
+"""
+Test the Frog lemmatizer functions and task
+"""
+
+import logging
+import socket
+from unittest import SkipTest
+
+from nose.tools import assert_equal, assert_not_equal
+
+from xtas.tasks.frog import *
+
+
+def _check_frog():
+    s = socket.socket()
+    try:
+        s.connect((FROG_HOST, FROG_PORT))
+    except:
+        logging.exception("Unable to connect to {}:{}, skipping tests"
+                          .format(FROG_HOST, FROG_PORT))
+        raise SkipTest("Cannot connect to frog, skipping tests")
+
+    logging.info("Frog is alive!")
+
+
+def test_call_frog():
+    _check_frog()
+    lines = list(call_frog("dit is in Amsterdam. Tweede zin!"))
+    assert_equal(len(lines), 10)
+    test = lines[3].split("\t")[:5]
+    assert_equal(test, ['4', 'Amsterdam', 'Amsterdam', '[Amsterdam]',
+                        'SPEC(deeleigen)'])
+    assert_equal(lines[5], '')
+
+
+LINES = ['1\tdit\tdit\t[dit]\tVNW(aanw,pron,stan,vol,3o,ev)\t0.9\tO\tB-NP\t\t',
+         '2\tis\tzijn\t[zijn]\tWW(pv,tgw,ev)\t0.9\tO\tB-VP\t\t',
+         '3\tin\tin\t[in]\tVZ(init)\t0.998321\tO\tB-PP\t\t',
+         '4\tAmsterdam\tAmsterdam\t[Amsterdam]\tSPEC(deeleigen)'
+         '\t1.000000\tB-LOC\tB-NP\t\t',
+         '5\t.\t.\t[.]\tLET()\t0.999956\tO\tO\t\t',
+         '',
+         '1\tTweede\ttwee\t[twee][de]\tTW(rang,prenom,stan)\t0.9\tO\tB-NP\t\t',
+         '2\tzin\tzin\t[zin]\tN(soort,ev,basis,zijd,stan)\t0.99\tO\tI-NP\t\t',
+         '3\t!\t!\t[!]\tLET()\t0.995005\tO\tO\t\t',
+         '']
+
+
+def test_parse_frog():
+    tokens = list(parse_frog(LINES))
+    assert_equal(len(tokens), 8)
+    expected = dict(id=0, sentence=0,
+                    lemma='dit', word='dit',
+                    pos='VNW(aanw,pron,stan,vol,3o,ev)',
+                    pos_confidence=0.9)
+    assert_equal(tokens[0], expected)
+    assert_equal(tokens[7]['sentence'], 1)
+
+
+def test_frog_to_saf():
+    tokens = list(parse_frog(LINES))
+    saf = frog_to_saf(tokens)
+    assert_equal(len(saf['tokens']), 8)
+    token = [t for t in saf['tokens'] if t['lemma'] == 'Amsterdam']
+    assert_equal(len(token), 1)
+    assert_equal(token[0]['pos1'], 'M')
+
+
+def test_frog_task():
+    "Test whether the xtas.tasks.single.frog call works"
+    _check_frog()
+    from xtas.tasks.single import frog
+    raw = frog("dit is een test", output='raw')
+    assert_equal(len(raw), 5)
+    assert_equal(raw[4], '')
+    tokens = frog("dit is een test", output='tokens')
+    assert_equal(len(tokens), 4)
+    assert_equal(tokens[0]['lemma'], 'dit')
+    saf = frog("dit is een test", output='saf')
+    assert_equal(len(saf['tokens']), 4)
+    assert_equal(saf['header']['processed'][0]['module'], 'frog')


### PR DESCRIPTION
Added a new module and task for the frog lemmatizer/POS tagger
- Pending #34, the module expects the frog server to be running at localhost:9887 (configurable via global variables FROG_{HOST,PORT}
- Output can be configured via task parameter 'output', supporting raw, tokens, or saf 
