### PR TITLE
Improve error handling in case of failed download

### DIFF
--- a/xtas/tasks/_emotion.py
+++ b/xtas/tasks/_emotion.py
@@ -28,8 +28,13 @@ def download():
     path = os.path.join(data_home, "movie_review_emotions.txt")
     if not os.path.exists(path):
         tmp = NamedTemporaryFile(prefix=data_home, delete=False)
-        for part in ["train.txt", "test.txt"]:
-            copyfileobj(urlopen(_BASE_URL + part), tmp)
+        try:
+            for part in ["train.txt", "test.txt"]:
+                copyfileobj(urlopen(_BASE_URL + part), tmp)
+        except:
+            tmp.close()
+            os.remove(tmp)
+            raise
         tmp.close()
         move(tmp.name, path)
     return path


### PR DESCRIPTION
The Python docs regrettably do not tell us what happens if copyfileobj runs into some error, but it seems quite possible that the target file isn't cleaned up. This fixes that.