### PR TITLE
Frog fixes

### DIFF
--- a/xtas/tasks/_frog.py
+++ b/xtas/tasks/_frog.py
@@ -39,7 +39,7 @@ _POSMAP = {"VZ": "P",
 def call_frog(text):
     """
     Call the frog parser on the given host and port with the given text
-    Returns a file object containing the output lines.
+    Is a generator over the output lines.
     """
     if not text.endswith("\n"):
         text = text + "\n"
@@ -62,7 +62,7 @@ def call_frog(text):
 def parse_frog(lines):
     """
     Interpret the output of the frog parser.
-    Input should be a sequence of lines (i.e. the output of call_frog)
+    Input should be an iterable of lines (i.e. the output of call_frog)
     Result is a sequence of dicts representing the tokens
     """
     sid = 0

--- a/xtas/tasks/_frog.py
+++ b/xtas/tasks/_frog.py
@@ -66,21 +66,22 @@ def parse_frog(lines):
     Result is a sequence of dicts representing the tokens
     """
     sid = 0
-    for i, l in enumerate(lines):
-        if not l:
+    for i, line in enumerate(lines):
+        if not line:
             # end of sentence marker
             sid += 1
         else:
-            print(l.strip())
-            parts = l.split("\t")
+            print(line.strip())
+            parts = line.split("\t")
             tid, token, lemma, morph, pos, conf, ne, _, parent, rel = parts
             if rel:
                 rel = (rel, int(parent) - 1)
-            r = dict(id=i, sentence=sid, word=token, lemma=lemma,
-                     pos=pos, pos_confidence=float(conf),
-                     rel=rel)
+            result = dict(id=i, sentence=sid, word=token, lemma=lemma,
+                          pos=pos, pos_confidence=float(conf),
+                          rel=rel)
             if ne != 'O':
-                r["ne"] = ne.split('_', 1)[0][2:]   # NER label from BIO tags
+                # NER label from BIO tags
+                result["ne"] = ne.split('_', 1)[0][2:]
             yield r
 
 

--- a/xtas/tasks/_frog.py
+++ b/xtas/tasks/_frog.py
@@ -98,7 +98,7 @@ def frog_to_saf(tokens):
     """
     Convert frog tokens into a new SAF document
     """
-    tokens = [add_pos1(token) for token in tokens]
+    tokens = map(add_pos1, tokens)
     module = {'module': "frog",
               "started": datetime.datetime.now().isoformat()}
     return {"header": {'format': "SAF",

--- a/xtas/tasks/_frog.py
+++ b/xtas/tasks/_frog.py
@@ -82,7 +82,7 @@ def parse_frog(lines):
             if ne != 'O':
                 # NER label from BIO tags
                 result["ne"] = ne.split('_', 1)[0][2:]
-            yield r
+            yield result
 
 
 def add_pos1(token):

--- a/xtas/tasks/_frog.py
+++ b/xtas/tasks/_frog.py
@@ -45,7 +45,7 @@ def call_frog(text):
         text = text + "\n"
     if not isinstance(text, unicode):
         text = unicode(text)
-    text = unidecode(text).encode("utf-8")
+    text = unidecode(text)
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect((FROG_HOST, FROG_PORT))


### PR DESCRIPTION
Small fixes to _frog.py(). The output of unidecode() is 7-bit ASCII, which is a subset of UTF-8, so no additional conversion is necessary.