### PR TITLE
Return correct HTTP error on incorrect media type

### DIFF
--- a/xtas/webserver/__init__.py
+++ b/xtas/webserver/__init__.py
@@ -60,7 +60,7 @@ def run_task(taskname):
         kwargs = request.json.get('arguments', {})
         return task.delay(data, **kwargs).id + "\n"
 
-    abort(404)  # XXX this is not the right error code
+    abort(415)  # Unsupported Media Type
 
 
 @app.route("/run_es/<taskname>/<index>/<type>/<id>/<field>")


### PR DESCRIPTION
There are some other comments in this file complaining about various things, but those seem to be feature requests, not bugs, so I left them alone.