### PR TITLE
Pipeline fixes

### DIFF
--- a/xtas/tasks/pipeline.py
+++ b/xtas/tasks/pipeline.py
@@ -13,7 +13,7 @@ def pipeline(doc, pipeline, store_final=True, store_intermediate=False,
              block=True):
     """
     Get the result for a given document.
-    Pipeline should be a list of dicts, with members task and argument
+    Pipeline should be a list of dicts, with members module and arguments
     e.g. [{"module" : "tokenize"},
           {"module" : "pos_tag", "arguments" : {"model" : "nltk"}}]
     @param block: if True, it will block and return the actual result.


### PR DESCRIPTION
This one is a bit more scary than my previous contributions. Commit 511c1b4 mostly rewrites pipeline(). As far as I can tell the original is actually correct, but determining that was not so easy. The new version should be doing the exact same thing, but is more obviously correct. It passes the unit tests, but is otherwise untested. Please review carefully.