### PR TITLE
Notes on cluster.py

### DIFF
--- a/xtas/tasks/cluster.py
+++ b/xtas/tasks/cluster.py
@@ -190,7 +190,7 @@ def lda(docs, k):
 
 @app.task
 def parsimonious_wordcloud(docs, w=.5, k=10):
-    """Fit a parsimonious language model to terms in docs."""
+    """Fit a parsimonious language model to terms in docs.""" #
     from weighwords import ParsimoniousLM
 
     model = ParsimoniousLM(docs, w=w)


### PR DESCRIPTION
`parsimonious_wordcloud()` should have its arguments and return value documented. Who are w and k and what do they have to do with clouds?